### PR TITLE
Bump deployment target

### DIFF
--- a/Pantomime.podspec
+++ b/Pantomime.podspec
@@ -14,9 +14,9 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/thomaschristensen/Pantomime"
   s.license      = "MIT"
   s.author       = { "Thomas Christensen" => "tchristensen@nordija.com" }
-  s.ios.deployment_target = "8.0"
-  s.tvos.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "12.0"
+  s.tvos.deployment_target = "12.0"
+  s.osx.deployment_target = "11.0"
   s.source       = { :git => "https://github.com/thomaschristensen/Pantomime.git", :tag => "0.1.4" }
   s.source_files  = "sources"
 end


### PR DESCRIPTION
Xcode removed `libarclite_iphoneos.a` from its toolchain, breaking the build of `Tacx-streaming/iOS-Demo`.

Bumping the deployment target fixes the issue.